### PR TITLE
Add terraform validation pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -21,3 +21,27 @@
   always_run: true
   language: script
   pass_filenames: false
+
+- id: tf_required_files
+  name: Terraform required files
+  description: Enforce every directory with .tf files has terraform.tf and README.md
+  entry: tf_required_files.sh
+  language: script
+  files: (\.tf)$
+  exclude: \.terraform\/.*$
+
+- id: s3_backend_config
+  name: S3 backend bucket and region
+  description: Enforce S3 backend blocks use bucket cru-tf-remote-state in us-east-1
+  entry: s3_backend_config.sh
+  language: script
+  files: (\.tf)$
+  exclude: \.terraform\/.*$
+
+- id: tf_version_constraints
+  name: Terraform provider version constraints
+  description: Enforce provider version constraints use pessimistic operator (~>)
+  entry: tf_version_constraints.sh
+  language: script
+  files: (\.tf)$
+  exclude: \.terraform\/.*$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+- New `tf_required_files` hook: enforces every directory with `.tf` files has `terraform.tf` and `README.md`
+- New `s3_backend_config` hook: enforces S3 backend blocks use bucket `cru-tf-remote-state` in region `us-east-1`, auto-corrects incorrect values
+- New `tf_version_constraints` hook: enforces provider version constraints use pessimistic operator (`~>`)
+
 ## [v1.4.1] - 2026-2-27
 ### Fixed
 - `tf_validate_config` always runs (version check fires even when no `.tf` files changed)

--- a/README.md
+++ b/README.md
@@ -15,12 +15,18 @@ Create or update `.pre-commit-config.yaml`:
     - id: s3_backend_key
     - id: tf_provider_lock
     - id: tf_validate_config
+    - id: tf_required_files
+    - id: s3_backend_config
+    - id: tf_version_constraints
 ```
 
 ## Hooks
 - [`s3_backend_key`](#s3_backend_key) - Enforce the `key` property of `backend "s3"` to match folder paths for terraform files.
 - [`tf_provider_lock`](#tf_provider_lock) - Add MacOS and Linux provider hashes to dependency lock file.
 - [`tf_validate_config`](#tf_validate_config) - Enforce terraform version, backend lockfile, and required_version constraints.
+- [`tf_required_files`](#tf_required_files) - Enforce every terraform directory has `terraform.tf` and `README.md`.
+- [`s3_backend_config`](#s3_backend_config) - Enforce S3 backend uses correct bucket and region.
+- [`tf_version_constraints`](#tf_version_constraints) - Enforce provider version constraints use pessimistic operator (`~>`).
 
 ## Details
 #### s3_backend_key
@@ -41,3 +47,17 @@ This hook auto-corrects three terraform configuration issues:
 - **required_version**: Updates the `required_version` constraint in the `terraform {}` block to `"~> <version>"` from `.tool-versions`.
 
 Modified files are automatically formatted with `terraform fmt`.
+
+#### tf_required_files
+This hook verifies that every directory containing `.tf` files also has both `terraform.tf` and `README.md`. It checks
+only the directories of changed files, not the entire repo.
+
+#### s3_backend_config
+This hook enforces that all `backend "s3"` blocks use the correct bucket (`cru-tf-remote-state`) and region
+(`us-east-1`). Incorrect values are auto-corrected in place. This complements `s3_backend_key` which validates the
+state key path.
+
+#### tf_version_constraints
+This hook checks that provider version constraints in `required_providers` blocks use the pessimistic operator (`~>`).
+Constraints using `=`, `>=`, or bare versions will be flagged. This prevents exact pinning and overly permissive
+version ranges.

--- a/s3_backend_config.sh
+++ b/s3_backend_config.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Enforce that all S3 backend blocks use the correct bucket and region:
+#   - bucket  = "cru-tf-remote-state"
+#   - region  = "us-east-1"
+# Auto-corrects incorrect values. Pre-commit passes .tf filenames as arguments.
+
+set -e
+
+EXPECTED_BUCKET="cru-tf-remote-state"
+EXPECTED_REGION="us-east-1"
+
+updated_files=()
+
+for file in "$@"; do
+  [ -f "$file" ] || continue
+
+  # Check if file has a backend "s3" block
+  has_backend=$(awk '/backend[[:space:]]+"s3"[[:space:]]*\{/ { print "yes"; exit }' "$file")
+  [ "$has_backend" = "yes" ] || continue
+
+  file_modified=false
+
+  # Extract current bucket value from backend "s3" block
+  actual_bucket=$(awk '
+    /backend[[:space:]]+"s3"[[:space:]]*\{/ { in_backend=1; next }
+    in_backend && /\}/ { in_backend=0; next }
+    in_backend && /bucket[[:space:]]*=[[:space:]]*"/ {
+      val=$0
+      sub(/.*bucket[[:space:]]*=[[:space:]]*"/, "", val)
+      sub(/".*/, "", val)
+      print val
+      exit
+    }
+  ' "$file")
+
+  if [ -n "$actual_bucket" ] && [ "$actual_bucket" != "$EXPECTED_BUCKET" ]; then
+    awk -v expected="$EXPECTED_BUCKET" '
+      /backend[[:space:]]+"s3"[[:space:]]*\{/ { in_backend=1 }
+      in_backend && /\}/ { in_backend=0 }
+      in_backend && /bucket[[:space:]]*=[[:space:]]*"/ {
+        sub(/bucket[[:space:]]*=[[:space:]]*"[^"]*"/, "bucket         = \"" expected "\"")
+      }
+      { print }
+    ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+    file_modified=true
+  fi
+
+  # Extract current region value from backend "s3" block
+  actual_region=$(awk '
+    /backend[[:space:]]+"s3"[[:space:]]*\{/ { in_backend=1; next }
+    in_backend && /\}/ { in_backend=0; next }
+    in_backend && /region[[:space:]]*=[[:space:]]*"/ {
+      val=$0
+      sub(/.*region[[:space:]]*=[[:space:]]*"/, "", val)
+      sub(/".*/, "", val)
+      print val
+      exit
+    }
+  ' "$file")
+
+  if [ -n "$actual_region" ] && [ "$actual_region" != "$EXPECTED_REGION" ]; then
+    awk -v expected="$EXPECTED_REGION" '
+      /backend[[:space:]]+"s3"[[:space:]]*\{/ { in_backend=1 }
+      in_backend && /\}/ { in_backend=0 }
+      in_backend && /region[[:space:]]*=[[:space:]]*"/ {
+        sub(/region[[:space:]]*=[[:space:]]*"[^"]*"/, "region         = \"" expected "\"")
+      }
+      { print }
+    ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+    file_modified=true
+  fi
+
+  if [ "$file_modified" = true ]; then
+    updated_files+=("$file")
+  fi
+done
+
+if [ ${#updated_files[@]} -eq 0 ]; then
+  exit 0
+fi
+
+echo "The following files had incorrect S3 backend configuration and were updated:"
+for file in "${updated_files[@]}"; do
+  echo "  - $file"
+done
+echo ""
+echo "Expected: bucket = \"$EXPECTED_BUCKET\", region = \"$EXPECTED_REGION\""
+echo "Please review the changes, stage them, and re-commit."
+exit 1

--- a/tf_required_files.sh
+++ b/tf_required_files.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Enforce that every directory containing .tf files also has:
+#   - terraform.tf (main terraform configuration)
+#   - README.md (documentation)
+# Pre-commit passes .tf filenames as arguments.
+
+set -e
+
+missing=()
+
+# Collect unique directories from the changed .tf files
+dirs=$(for file in "$@"; do dirname "$file"; done | sort -u)
+
+for dir in $dirs; do
+  [ -d "$dir" ] || continue
+
+  if [ ! -f "$dir/terraform.tf" ]; then
+    missing+=("$dir/terraform.tf")
+  fi
+
+  if [ ! -f "$dir/README.md" ]; then
+    missing+=("$dir/README.md")
+  fi
+done
+
+if [ ${#missing[@]} -eq 0 ]; then
+  exit 0
+fi
+
+echo "The following required files are missing:"
+for file in "${missing[@]}"; do
+  echo "  - $file"
+done
+echo ""
+echo "Every directory containing .tf files must have both terraform.tf and README.md."
+exit 1

--- a/tf_version_constraints.sh
+++ b/tf_version_constraints.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Enforce that provider version constraints use pessimistic operator (~>).
+# Checks required_providers blocks for version strings that use exact (=),
+# minimum (>=), or bare version pinning instead of ~>.
+# Pre-commit passes .tf filenames as arguments.
+
+set -e
+
+violations=()
+
+for file in "$@"; do
+  [ -f "$file" ] || continue
+
+  # Extract version constraints from required_providers blocks
+  # Look for lines like: version = "= 5.0.0" or version = ">= 3.0"
+  # but not version = "~> 5.0" (which is correct)
+  bad_constraints=$(awk '
+    /required_providers[[:space:]]*\{/ { in_rp=1; depth=1; next }
+    in_rp && /\{/ { depth++ }
+    in_rp && /\}/ { depth--; if (depth==0) in_rp=0; next }
+    in_rp && /version[[:space:]]*=[[:space:]]*"/ {
+      line=$0
+      # Extract the version string
+      val=line
+      sub(/.*version[[:space:]]*=[[:space:]]*"/, "", val)
+      sub(/".*/, "", val)
+      # Flag if it does not start with ~>
+      if (val !~ /^~>/) {
+        # Print file:line_number:constraint for reporting
+        printf "%s:%d: version = \"%s\"\n", FILENAME, NR, val
+      }
+    }
+  ' "$file")
+
+  if [ -n "$bad_constraints" ]; then
+    while IFS= read -r line; do
+      violations+=("$line")
+    done <<< "$bad_constraints"
+  fi
+done
+
+if [ ${#violations[@]} -eq 0 ]; then
+  exit 0
+fi
+
+echo "Provider version constraints must use the pessimistic operator (~>)."
+echo ""
+echo "The following violations were found:"
+for v in "${violations[@]}"; do
+  echo "  $v"
+done
+echo ""
+echo "Example fix: version = \">= 5.0\" -> version = \"~> 5.0\""
+exit 1


### PR DESCRIPTION
## Summary
- **`tf_required_files`**: Enforces every directory with `.tf` files has both `terraform.tf` and `README.md`
- **`s3_backend_config`**: Enforces S3 backend blocks use bucket `cru-tf-remote-state` in region `us-east-1`, auto-corrects incorrect values
- **`tf_version_constraints`**: Enforces provider version constraints in `required_providers` use the pessimistic operator (`~>`)

These hooks were identified as good candidates from the [cru-terraform CLAUDE.md](https://github.com/CruGlobal/cru-terraform/blob/main/CLAUDE.md) coding standards — policies that are file-level, objective, deterministic, and enforceable at pre-commit time.

## Test plan
- [ ] Test `tf_required_files` with a directory missing `README.md` or `terraform.tf`
- [ ] Test `s3_backend_config` with an incorrect bucket name and verify auto-correction
- [ ] Test `s3_backend_config` with an incorrect region and verify auto-correction
- [ ] Test `tf_version_constraints` with `version = ">= 5.0"` and verify it flags the violation
- [ ] Test `tf_version_constraints` with `version = "~> 5.0"` and verify it passes
- [ ] Run all hooks against the cru-terraform repo to validate no false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)