### PR TITLE
Exclude aws/route53 from README.md requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changed
+- `tf_required_files` now excludes `aws/route53` and its child directories from the `README.md` requirement
+
 ## [v1.5.0] - 2026-3-5
 ### Added
 - New `tf_required_files` hook: enforces every directory with `.tf` files has `terraform.tf` and `README.md`

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Modified files are automatically formatted with `terraform fmt`.
 This hook verifies that every directory containing `.tf` files also has both `terraform.tf` and `README.md`. It checks
 only the directories of changed files, not the entire repo.
 
+Some directories are excluded from the `README.md` requirement (e.g., `aws/route53` and its children). The
+`terraform.tf` requirement is always enforced.
+
 #### s3_backend_config
 This hook enforces that all `backend "s3"` blocks use the correct bucket (`cru-tf-remote-state`) and region
 (`us-east-1`). Incorrect values are auto-corrected in place. This complements `s3_backend_key` which validates the

--- a/tf_required_files.sh
+++ b/tf_required_files.sh
@@ -7,6 +7,11 @@
 
 set -e
 
+# Directories excluded from the README.md requirement (matched as prefix)
+EXCLUDED_README_DIRS=(
+  "aws/route53"
+)
+
 missing=()
 
 # Collect unique directories from the changed .tf files
@@ -19,7 +24,16 @@ for dir in $dirs; do
     missing+=("$dir/terraform.tf")
   fi
 
-  if [ ! -f "$dir/README.md" ]; then
+  # Check README.md unless directory is excluded
+  skip_readme=false
+  for excluded in "${EXCLUDED_README_DIRS[@]}"; do
+    if [[ "$dir" == "$excluded" || "$dir" == "$excluded"/* ]]; then
+      skip_readme=true
+      break
+    fi
+  done
+
+  if [ "$skip_readme" = false ] && [ ! -f "$dir/README.md" ]; then
     missing+=("$dir/README.md")
   fi
 done


### PR DESCRIPTION
## Summary
- Excludes `aws/route53` and its child directories from the `README.md` requirement in `tf_required_files` hook
- `terraform.tf` is still enforced for those directories
- Uses an `EXCLUDED_README_DIRS` array for easy future additions

## Test plan

### Local testing setup
To test against the `cru-terraform` repo using your local clone of `cru-pre-commit-hooks`, temporarily update the `.pre-commit-config.yaml` in `cru-terraform` to point to your local path:

```yaml
# Change this:
- repo: git://github.com/CruGlobal/cru-pre-commit-hooks
  rev: v1.5.0

# To this:
- repo: /path/to/your/local/cru-pre-commit-hooks
  rev: fix/exclude-route53-from-required-files
```

Then run the hooks against all files:
```bash
cd /path/to/cru-terraform
pre-commit run tf_required_files --all-files
```

> **Note:** Remember to revert `.pre-commit-config.yaml` after testing.

### Unit tests

#### Setup
```bash
# Create test directories
mkdir -p /tmp/test-hook/aws/route53/zones
mkdir -p /tmp/test-hook/aws/ec2
```

#### 1. aws/route53 — should NOT flag missing README.md
```bash
echo 'resource "aws_route53_zone" "test" {}' > /tmp/test-hook/aws/route53/main.tf
touch /tmp/test-hook/aws/route53/terraform.tf
./tf_required_files.sh /tmp/test-hook/aws/route53/main.tf
# Expected: exit 0 (no error)
```

#### 2. aws/route53 child dir — should NOT flag missing README.md
```bash
echo 'resource "aws_route53_record" "test" {}' > /tmp/test-hook/aws/route53/zones/main.tf
touch /tmp/test-hook/aws/route53/zones/terraform.tf
./tf_required_files.sh /tmp/test-hook/aws/route53/zones/main.tf
# Expected: exit 0 (no error)
```

#### 3. aws/route53 missing terraform.tf — should still flag it
```bash
rm /tmp/test-hook/aws/route53/terraform.tf
./tf_required_files.sh /tmp/test-hook/aws/route53/main.tf
# Expected: exit 1, reports missing terraform.tf
```

#### 4. Other directory missing README.md — should flag it
```bash
echo 'resource "aws_instance" "test" {}' > /tmp/test-hook/aws/ec2/main.tf
touch /tmp/test-hook/aws/ec2/terraform.tf
./tf_required_files.sh /tmp/test-hook/aws/ec2/main.tf
# Expected: exit 1, reports missing README.md
```

#### Cleanup
```bash
rm -rf /tmp/test-hook
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)